### PR TITLE
Fix missing microk8s snap updates and channel changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ These variables are defined in [defaults/main.yml](./defaults/main.yml):
 
     microk8s_extra_args: {}     # key: file in /var/snap/microk8s/current/args/, value: extra content
 
+    microk8s_update: true
+
     microk8s_drain_node_on_update: false
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,4 +8,6 @@ microk8s_channel: "latest/stable"
 
 microk8s_extra_args: {}
 
+microk8s_update: true
+
 microk8s_drain_node_on_update: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,13 +7,13 @@
       - snapd
     state: present
 
-- name: node status
+- name: node | status
   command: "microk8s status --format=yaml"
   register: _node_status
   changed_when: false
   failed_when: false
 
-- name: drain nodes
+- name: node | drain
   when:
     - microk8s_drain_node_on_update
     - _node_status.rc == 0
@@ -23,7 +23,7 @@
   command: "microk8s kubectl drain {{ ansible_hostname }} {{ microk8s_drain_extra_args }}"
   notify: uncordon node
 
-- name: establish snap package
+- name: package | install
   become: true
   snap:
     name: microk8s
@@ -31,14 +31,22 @@
     classic: true
     channel: "{{ microk8s_channel }}"
 
-- name: add user to control group
+# TODO: workaround for https://github.com/ansible-collections/community.general/issues/1606
+- name: package | update
+  when: microk8s_update
+  become: true
+  command: "snap refresh microk8s --channel={{ microk8s_channel }}"
+  register: _snap_microk8s_refresh
+  changed_when: "'has no updates available' not in _snap_microk8s_refresh.stderr"
+
+- name: system | add user to control group
   become: true
   user:
     name: "{{ ansible_env.USER | default(ansible_user_id) }}"
     groups: microk8s
     append: true
 
-- name: reload users | reset host connection
+- name: system | reset host connection to reload users
   meta: reset_connection
 
 - name: config | hosts | dir
@@ -72,7 +80,7 @@
     marker: "## {mark} extra args - managed by Ansible"
   notify: restart node
 
-- name: enable addons
+- name: addons | enable
   become: true
   loop: "{{ microk8s_addons }}"
   command: "microk8s enable {{ item }}"


### PR DESCRIPTION
## What
Due to an issue (https://github.com/ansible-collections/community.general/issues/1606)  in `community.general.snap` module, channel changes and updates were not performed on the microk8s snap package the way a role user would expect.

This PR introduces a fix with enforced refreshes that introduce snap refresh mechanism using the `command` module.