### PR TITLE
Fix kubelet args formatting, restart kubelet handler name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .*.swp
 *.retry
+.idea/

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,7 +6,7 @@
     - start
   command: "microk8s {{ item }}"
 
-- name: restart kubelet
+- name: restart kubelite
   become: true
   ansible.builtin.systemd_service:
     name: snap.microk8s.daemon-kubelite

--- a/tasks/kubelet_args.yml
+++ b/tasks/kubelet_args.yml
@@ -12,7 +12,7 @@
     dest: /var/snap/microk8s/current/args/kubelet.orig
     remote_src: yes
   when: not kubelet_orig_file.stat.exists
-  notify: restart kubelet
+  notify: restart kubelite
 
 - name: config | component | kubelet args | slurp orig config
   ansible.builtin.slurp:

--- a/tasks/kubelet_args.yml
+++ b/tasks/kubelet_args.yml
@@ -12,7 +12,7 @@
     dest: /var/snap/microk8s/current/args/kubelet.orig
     remote_src: yes
   when: not kubelet_orig_file.stat.exists
-  notify: restart kubelite
+  notify: restart kubelet
 
 - name: config | component | kubelet args | slurp orig config
   ansible.builtin.slurp:

--- a/templates/kubelet_args.j2
+++ b/templates/kubelet_args.j2
@@ -1,4 +1,4 @@
 {{ kubelet_orig_file_content.content | b64decode }}
 {%- for item in microk8s_kubelet_additional_args | default([]) %}
 {{ item }}
-{%- endfor %}
+{% endfor %}


### PR DESCRIPTION
# What
- Ffix kubelet args formatting
  - The template with `{%- endfor %}` was putting all `microk8s_kubelet_additional_args` into a single line without spaces, causing microk8s `daemon-kubelite` to crash due to incorrect args format
  - Correct format is one argument per line
- Fix `restart kubelet` handler name -> `restart kubelite`